### PR TITLE
YGO-17: Remove card from deck-type

### DIFF
--- a/YGOCardSearch/Pages/DeckBuilder.cshtml
+++ b/YGOCardSearch/Pages/DeckBuilder.cshtml
@@ -85,12 +85,12 @@
             <!-- Deck content will be added dynamically using JavaScript -->
             <div class="DecksContainer">
                 <div class="DeckBuilder_DeckCards_Container">
-                    <h2>Main Deck [@Model.Deck.MainDeck.Count]</h2>
-                    <div class="DeckBuilder_Container_MainDeck" id="main-deck" data-deck-type="MainDeck" ondrop="drop(event)" ondragover="dragOver(event)"></div>
+                    <h2>Main Deck</h2>
+                    <div class="DeckBuilder_Container_MainDeck" id="main-deck" data-deck-type="MainDeck" ondrop="drop(event)" ondragover="dragOver(event)" ondragstart="dragStart(event)"></div>
                     <div class="RemoveFromDeckArea" id="remove-from-main-deck" ondrop="drop(event)" ondragover="dragOver(event)"></div>
-                    <h2>Extra deck: [@Model.Deck.ExtraDeck.Count]</h2>
+                    <h2>Extra deck:</h2>
                     <div class="DeckBuilder_Container_ExtraDeck" id="extra-deck" data-deck-type="ExtraDeck" ondrop="drop(event)" ondragover="dragOver(event)"></div>
-                    <h2>Side deck: [@Model.Deck.SideDeck.Count] </h2>
+                    <h2>Side deck:</h2>
                     <div class="DeckBuilder_Container_SideDeck" id="side-deck" data-deck-type="SideDeck" ondrop="drop(event)" ondragover="dragOver(event)"></div>
                 </div>
             </div>
@@ -109,16 +109,13 @@
                     </div>
                 </form>
             </div>
-            
-
             @*Where the searched cards will display*@
             <div class="DeckBuilder_CardSearch_JS">
             </div>
-        
         </div>
     </div>
     <div class="remove-area" > <!-- ondrag="dragStart(event)" ondragover="dragOver(event)" ondrop="drop(event)"-->
-                <img id="remove-area" class="remove-area" src="/images/trash-bin.png" ondrag="dragStart(event)" ondragover="dragOver(event)" ondrop="drop(event)"/>
+        <img id="remove-area" class="remove-area" src="/images/trash-bin.png" ondrag="dragStart(event)" ondragover="dragOver(event)" ondrop="drop(event)"/>
     </div>
 
     

--- a/YGOCardSearch/wwwroot/js/deck.js
+++ b/YGOCardSearch/wwwroot/js/deck.js
@@ -22,16 +22,26 @@ class Deck {
     }
 
     removeCardFromMainDeck(cardId) {
-        this.mainDeck = this.mainDeck.filter(card => card.id !== cardId);
+        const index = this.mainDeck.findIndex(card => card.id === cardId);
+        if (index !== -1) {
+            this.mainDeck.splice(index, 1);
+        }
     }
 
     removeCardFromExtraDeck(cardId) {
-        this.extraDeck = this.extraDeck.filter(card => card.id !== cardId);
+        const index = this.extraDeck.findIndex(card => card.id === cardId);
+        if (index !== -1) {
+            this.extraDeck.splice(index, 1);
+        }
     }
 
     removeCardFromSideDeck(cardId) {
-        this.sideDeck = this.sideDeck.filter(card => card.id !== cardId);
+        const index = this.sideDeck.findIndex(card => card.id === cardId);
+        if (index !== -1) {
+            this.sideDeck.splice(index, 1);
+        }
     }
+
 
     getMainDeck() {
         return this.mainDeck;

--- a/YGOCardSearch/wwwroot/js/interaction.js
+++ b/YGOCardSearch/wwwroot/js/interaction.js
@@ -1,4 +1,4 @@
-import { renderDeckCards } from './rendering.js'; // Import the rendering function
+import { renderDeckCards} from './rendering.js'; // Import the rendering function
 import {
     addCardToMainDeck,
     addCardToExtraDeck,
@@ -13,7 +13,7 @@ import {
 
 
 // Function to handle adding a card to a deck
-function handleAddToDeck(deckType, deck, card) {
+function handleAddToDeck(deckType, deck, card, onComplete) {
     switch (deckType) {
         case 'MainDeck':
             addCardToMainDeck(deck, card);
@@ -29,6 +29,10 @@ function handleAddToDeck(deckType, deck, card) {
     }
     renderDeckCards(getDeck(deck, deckType), `.DeckBuilder_Container_${deckType}`);
     console.log(`Added "${card.name} id: ${card.id}" to the ${deckType}.`);
+    // Call the onComplete function if provided
+    if (typeof onComplete === 'function') {
+        onComplete();
+    }
 }
 function getDeck(deck, deckType) {
     switch (deckType) {
@@ -45,7 +49,7 @@ function getDeck(deck, deckType) {
     }
 }
 // Function to handle removing a card from a deck
-function handleRemoveFromDeck(deckType, deck, card) {
+function handleRemoveFromDeck(deckType, deck, card, onComplete) {
     switch (deckType) {
         case 'MainDeck':
             removeCardFromMainDeck(deck, card);
@@ -61,6 +65,10 @@ function handleRemoveFromDeck(deckType, deck, card) {
     }
     renderDeckCards(getDeck(deck, deckType), `.DeckBuilder_Container_${deckType}`);
     console.log(`Removed card id: ${card} from the ${deckType}.`);
+    // Call the onComplete function if provided
+    if (typeof onComplete === 'function') {
+        onComplete();
+    }
 }
 // Function to update the displayed decks
 function updateDisplayedDecks() {

--- a/YGOCardSearch/wwwroot/js/rendering.js
+++ b/YGOCardSearch/wwwroot/js/rendering.js
@@ -1,6 +1,7 @@
 // Import the renderSearchedCards function if it's in a different module
 // import { renderSearchedCards } from './your-path-to-render-searched-cards.js';
 
+
 function renderDeckCards(deck, deckPart) {
     var deckContainer = document.querySelector(deckPart);
     deckContainer.innerHTML = '';
@@ -32,7 +33,6 @@ function renderDeckCards(deck, deckPart) {
     });
 }
 
-export { renderDeckCards };
 
 // Function to render searched cards
 
@@ -127,5 +127,5 @@ function renderSearchedCards(cards, containerSelector) {
     }
 }
 
-export { renderSearchedCards };
+export { renderDeckCards, renderSearchedCards };
 


### PR DESCRIPTION
What's the task... ✏️
Add remove card from deck functionality to DeckBuilder. 

Why we're doing it... 
This is for completing the DeckBuilder core page features which include: 

Adding card from search cards to any deck. 

Remove a card from any of the decks

Add rule of three repited cards only (will add the banlist later) 

Add rule of maximum cards per type of deck  (will add the banlist later) 

Add rule of type of cards to any deck (will add the banlist later)

Steps we'll take... 

Files to be modified: 
deckBuilder.js
interaction.js
deck.js

And probably DeckBuilder.cshtml

Success is... ✨
When a card from any deck is dragged outside the limits of their block, remove that card from deck.